### PR TITLE
Got rid of product_collection attribute

### DIFF
--- a/Plugin/Catalog/Model/Indexer/DataProvider/Product/BundleDataExtender.php
+++ b/Plugin/Catalog/Model/Indexer/DataProvider/Product/BundleDataExtender.php
@@ -26,10 +26,14 @@ class BundleDataExtender
                 continue;
             }
 
+            // It is not really a clone. However, it will make me so easier to search in PWA
+            $indexData[$product_id]['is_clone'] = 3;
+
             // Add slug_from_name for pretty URLs
             // I did same for Configurables
             // These functions are just equal `slugify`
-            $indexDataItem['slug_from_name'] = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $indexDataItem['name'])));
+            // $indexDataItem['slug_from_name'] = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $indexDataItem['name'])));
+            $indexData[$product_id]['slug_from_name'] = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $indexDataItem['name'])));
 
             $bundlePrice = $indexDataItem['price'] ?? null;
 

--- a/Plugin/Catalog/Model/Indexer/DataProvider/Product/ConfigurableDataExtender.php
+++ b/Plugin/Catalog/Model/Indexer/DataProvider/Product/ConfigurableDataExtender.php
@@ -117,14 +117,14 @@ class ConfigurableDataExtender {
                     $clones[$cloneId]['url_key'] = $indexDataItem['url_key'].'?color='.$clone_color;
                     $clones[$cloneId]['clone_name'] = $indexDataItem['name'].' '.$clones[$cloneId]['clone_color_label'];
 
-                    if ($clones[$cloneId]['product_collection']) {
-                        $product_collection_option = $this->loadOptionById->execute(
-                            'product_collection',
-                            $clones[$cloneId]['product_collection'],
-                            $storeId
-                        );
-                        $clones[$cloneId]['product_collection_label'] = $product_collection_option['label'];
-                    }
+                    // if ($clones[$cloneId]['product_collection']) {
+                    //     $product_collection_option = $this->loadOptionById->execute(
+                    //         'product_collection',
+                    //         $clones[$cloneId]['product_collection'],
+                    //         $storeId
+                    //     );
+                    //     $clones[$cloneId]['product_collection_label'] = $product_collection_option['label'];
+                    // }
 
                     $clones[$cloneId]['slug_from_name'] = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $clones[$cloneId]['clone_name'])));
 
@@ -147,14 +147,14 @@ class ConfigurableDataExtender {
                         $clones[$cloneId]['is_clone'] = 1;
                         $clones[$cloneId]['url_key'] = $indexDataItem['url_key'].'?color='.$clone_color;
                         $clones[$cloneId]['clone_name'] = $indexDataItem['name'].' '.$color['label'];
-                        if ($clones[$cloneId]['product_collection']) {
-                            $product_collection_option = $this->loadOptionById->execute(
-                                'product_collection',
-                                $clones[$cloneId]['product_collection'],
-                                $storeId
-                            );
-                            $clones[$cloneId]['product_collection_label'] = $product_collection_option['label'];
-                        }
+                        // if ($clones[$cloneId]['product_collection']) {
+                        //     $product_collection_option = $this->loadOptionById->execute(
+                        //         'product_collection',
+                        //         $clones[$cloneId]['product_collection'],
+                        //         $storeId
+                        //     );
+                        //     $clones[$cloneId]['product_collection_label'] = $product_collection_option['label'];
+                        // }
 
                         $clones[$cloneId]['slug_from_name'] = strtolower(trim(preg_replace('/[^A-Za-z0-9-]+/', '-', $clones[$cloneId]['clone_name'])));
 


### PR DESCRIPTION
As guys decided to remove `product_collection` attribute and make it category. It is not necessary anymore to add this attribute's label.

I commented it instead of removing because I anticipate we will do something similar with some other attribute so I will use it.

I also added is_clone = 3 attribute to bundles so it will be easier to fetch it from PWA for me (currently condition was is_clone <1;2>, I changed it to <1;3>)